### PR TITLE
fix: Point `import` export to dist and rename unused param

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./src/index.ts",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
     "./*": "./*"

--- a/src/VariablePolyfill.ts
+++ b/src/VariablePolyfill.ts
@@ -7,7 +7,7 @@ import { builders as b } from 'ast-types';
 import type { ParentKind } from './Constants';
 import { EXEMPT_IDENTIFIER_LIST } from './Constants';
 
-function assertNever(value: never): value is never {
+function assertNever(_value: never): _value is never {
 	return true;
 }
 


### PR DESCRIPTION
Consumers that use `moduleResolution: "bundler"` (Vite/Vue/modern TS) end up typechecking this package's TS source, not its emitted `.d.ts` files, because our `package.json` exports the `import` condition as `./src/index.ts`. This means any latent issue in our source becomes a typecheck failure in every downstream project.

This is blocking CI here: https://github.com/n8n-io/n8n/actions/runs/24719888187/job/72306327007

